### PR TITLE
Fix entry table parsing of null bundles and movable entry ordinals

### DIFF
--- a/MBBSDASM.Tests/Artifacts/EntryTableTests.cs
+++ b/MBBSDASM.Tests/Artifacts/EntryTableTests.cs
@@ -1,0 +1,75 @@
+using System.IO;
+using MBBSDASM.Artifacts;
+using Xunit;
+
+namespace MBBSDASM.Tests.Artifacts
+{
+    public class EntryTableTests
+    {
+        private static NEFile Load(byte[] entryTable)
+        {
+            var inputFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(inputFile, MinimalNEFile.Build(new byte[] {0xC3}, entryTable));
+                return new NEFile(inputFile);
+            }
+            finally
+            {
+                File.Delete(inputFile);
+            }
+        }
+
+        [Fact]
+        public void NullBundle_ReservesCountOrdinals()
+        {
+            var file = Load(new byte[]
+            {
+                0x03, 0x00,                         //null bundle: ordinals 1-3 unused
+                0x01, 0x01, 0x00, 0x10, 0x00,       //fixed bundle: 1 entry in segment 1, offset 0x0010
+                0x00                                //end of table
+            });
+
+            var entry = Assert.Single(file.EntryTable);
+            Assert.Equal(4, entry.Ordinal);
+            Assert.Equal(1, entry.SegmentNumber);
+            Assert.Equal(0x0010, entry.Offset);
+        }
+
+        [Fact]
+        public void MovableEntry_GetsOrdinalSegmentAndOffset()
+        {
+            var file = Load(new byte[]
+            {
+                0x02, 0x01, 0x00, 0x10, 0x00, 0x00, 0x20, 0x00, //fixed bundle: 2 entries in segment 1
+                0x01, 0xFF, 0x01, 0xCD, 0x3F, 0x01, 0x30, 0x00, //movable bundle: flag, int 3Fh, segment 1, offset 0x0030
+                0x00                                            //end of table
+            });
+
+            Assert.Equal(3, file.EntryTable.Count);
+            Assert.Equal(1, file.EntryTable[0].Ordinal);
+            Assert.Equal(0x0010, file.EntryTable[0].Offset);
+            Assert.Equal(2, file.EntryTable[1].Ordinal);
+            Assert.Equal(0x0020, file.EntryTable[1].Offset);
+
+            var movable = file.EntryTable[2];
+            Assert.Equal(3, movable.Ordinal);
+            Assert.Equal(1, movable.SegmentNumber);
+            Assert.Equal(0x0030, movable.Offset);
+        }
+
+        [Fact]
+        public void EndOfTableBundle_StopsParsing()
+        {
+            //Bytes after the terminator must not be parsed as further bundles
+            var file = Load(new byte[]
+            {
+                0x01, 0x01, 0x00, 0x10, 0x00,       //fixed bundle: 1 entry in segment 1
+                0x00,                               //end of table
+                0x01, 0x01, 0x00, 0x99, 0x00        //garbage past the terminator
+            });
+
+            Assert.Single(file.EntryTable);
+        }
+    }
+}

--- a/MBBSDASM.Tests/Dasm/JumpResolutionTests.cs
+++ b/MBBSDASM.Tests/Dasm/JumpResolutionTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using System.Linq;
+using MBBSDASM.Dasm;
+using MBBSDASM.Enums;
+using Xunit;
+
+namespace MBBSDASM.Tests.Dasm
+{
+    /// <summary>
+    ///     End-to-end tests for jump target resolution: builds a minimal NE file around a
+    ///     hand-crafted code segment and verifies the branch records after disassembly
+    /// </summary>
+    public class JumpResolutionTests
+    {
+        /*
+        *   0000: 90            nop
+        *   0001: EB 03         jmp short 0x6   (forward)
+        *   0003: E9 FA FF      jmp 0x0         (backward near)
+        *   0006: 0F 85 F7 FF   jnz 0x1         (backward near conditional, 2-byte opcode)
+        *   000A: FF E0         jmp ax          (indirect, no static target)
+        *   000C: C3            ret
+        */
+        private static readonly byte[] CodeSegment =
+        {
+            0x90,
+            0xEB, 0x03,
+            0xE9, 0xFA, 0xFF,
+            0x0F, 0x85, 0xF7, 0xFF,
+            0xFF, 0xE0,
+            0xC3
+        };
+
+        [Fact]
+        public void ResolveJumpTargets_LabelsRelativeJumps()
+        {
+            var inputFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(inputFile, BuildNEFile(CodeSegment));
+                var segment = new Disassembler(inputFile).Disassemble().SegmentTable[0];
+
+                //jmp short 0x6 from 0001
+                var fromShortJump = Assert.Single(LineAt(segment, 0x6).BranchFromRecords);
+                Assert.Equal(0x1UL, fromShortJump.Offset);
+                Assert.Equal(EnumBranchType.Unconditional, fromShortJump.BranchType);
+
+                //jmp 0x0 from 0003 -- backward near jump, must land on 0x0, not 0x1
+                var fromNearJump = Assert.Single(LineAt(segment, 0x0).BranchFromRecords);
+                Assert.Equal(0x3UL, fromNearJump.Offset);
+                Assert.Equal(EnumBranchType.Unconditional, fromNearJump.BranchType);
+
+                //jnz 0x1 from 0006 -- 0F 8x near conditional
+                var fromNearConditional = Assert.Single(LineAt(segment, 0x1).BranchFromRecords);
+                Assert.Equal(0x6UL, fromNearConditional.Offset);
+                Assert.Equal(EnumBranchType.Conditional, fromNearConditional.BranchType);
+
+                //jmp ax has no static target and must produce no branch records
+                Assert.Empty(LineAt(segment, 0xA).BranchToRecords);
+            }
+            finally
+            {
+                File.Delete(inputFile);
+            }
+        }
+
+        private static DisassemblyLine LineAt(MBBSDASM.Artifacts.Segment segment, ulong offset) =>
+            segment.DisassemblyLines.First(x => x.Disassembly.Offset == offset);
+
+        /// <summary>
+        ///     Builds the smallest NE file NEFile.Load will accept: MZ stub, NE header,
+        ///     one fixed code segment (with an empty relocation table), and empty name/entry tables
+        /// </summary>
+        private static byte[] BuildNEFile(byte[] code)
+        {
+            const int neHeaderOffset = 0x80;
+            const int segmentTableOffset = 0x40;  //relative to NE header
+            const int entryTableOffset = 0x60;    //relative to NE header
+            const int residentNameOffset = 0x62;  //relative to NE header
+            const int segmentDataOffset = 0x100;
+
+            var file = new byte[0x200];
+
+            //MZ stub
+            WriteUInt16(file, 0x00, 0x5A4D);            //'MZ'
+            file[0x18] = 0x40;                          //relocation table at 0x40 -> NE offset at 0x3C is valid
+            WriteUInt16(file, 0x3C, neHeaderOffset);
+
+            //NE header
+            file[neHeaderOffset] = (byte) 'N';
+            file[neHeaderOffset + 1] = (byte) 'E';
+            WriteUInt16(file, neHeaderOffset + 0x04, entryTableOffset);
+            WriteUInt16(file, neHeaderOffset + 0x1C, 1);                    //segment table entries
+            WriteUInt16(file, neHeaderOffset + 0x22, segmentTableOffset);
+            WriteUInt16(file, neHeaderOffset + 0x26, residentNameOffset);
+            WriteUInt16(file, neHeaderOffset + 0x28, residentNameOffset + 2); //module ref table (empty)
+            WriteUInt32(file, neHeaderOffset + 0x2C, (uint) file.Length);     //non-resident names (empty)
+            //LogicalSectorAlignmentShift (0x32), table lengths, and counts stay 0
+
+            //Segment table: one fixed code segment with relocation info present but empty
+            WriteUInt16(file, neHeaderOffset + segmentTableOffset, segmentDataOffset);
+            WriteUInt16(file, neHeaderOffset + segmentTableOffset + 2, (ushort) code.Length);
+            WriteUInt16(file, neHeaderOffset + segmentTableOffset + 4, 0x0100); //code + HasRelocationInfo
+            WriteUInt16(file, neHeaderOffset + segmentTableOffset + 6, (ushort) code.Length);
+
+            //Entry table (count byte 0) and resident name table (terminator) are already zeroed
+
+            //Segment data followed by a zero-entry relocation table
+            Array.Copy(code, 0, file, segmentDataOffset, code.Length);
+            WriteUInt16(file, segmentDataOffset + code.Length, 0);
+
+            return file;
+        }
+
+        private static void WriteUInt16(byte[] buffer, int offset, ushort value) =>
+            Array.Copy(BitConverter.GetBytes(value), 0, buffer, offset, 2);
+
+        private static void WriteUInt32(byte[] buffer, int offset, uint value) =>
+            Array.Copy(BitConverter.GetBytes(value), 0, buffer, offset, 4);
+    }
+}

--- a/MBBSDASM.Tests/Dasm/JumpResolutionTests.cs
+++ b/MBBSDASM.Tests/Dasm/JumpResolutionTests.cs
@@ -37,7 +37,7 @@ namespace MBBSDASM.Tests.Dasm
             var inputFile = Path.GetTempFileName();
             try
             {
-                File.WriteAllBytes(inputFile, BuildNEFile(CodeSegment));
+                File.WriteAllBytes(inputFile, MinimalNEFile.Build(CodeSegment));
                 var segment = new Disassembler(inputFile).Disassemble().SegmentTable[0];
 
                 //jmp short 0x6 from 0001
@@ -66,56 +66,5 @@ namespace MBBSDASM.Tests.Dasm
 
         private static DisassemblyLine LineAt(MBBSDASM.Artifacts.Segment segment, ulong offset) =>
             segment.DisassemblyLines.First(x => x.Disassembly.Offset == offset);
-
-        /// <summary>
-        ///     Builds the smallest NE file NEFile.Load will accept: MZ stub, NE header,
-        ///     one fixed code segment (with an empty relocation table), and empty name/entry tables
-        /// </summary>
-        private static byte[] BuildNEFile(byte[] code)
-        {
-            const int neHeaderOffset = 0x80;
-            const int segmentTableOffset = 0x40;  //relative to NE header
-            const int entryTableOffset = 0x60;    //relative to NE header
-            const int residentNameOffset = 0x62;  //relative to NE header
-            const int segmentDataOffset = 0x100;
-
-            var file = new byte[0x200];
-
-            //MZ stub
-            WriteUInt16(file, 0x00, 0x5A4D);            //'MZ'
-            file[0x18] = 0x40;                          //relocation table at 0x40 -> NE offset at 0x3C is valid
-            WriteUInt16(file, 0x3C, neHeaderOffset);
-
-            //NE header
-            file[neHeaderOffset] = (byte) 'N';
-            file[neHeaderOffset + 1] = (byte) 'E';
-            WriteUInt16(file, neHeaderOffset + 0x04, entryTableOffset);
-            WriteUInt16(file, neHeaderOffset + 0x1C, 1);                    //segment table entries
-            WriteUInt16(file, neHeaderOffset + 0x22, segmentTableOffset);
-            WriteUInt16(file, neHeaderOffset + 0x26, residentNameOffset);
-            WriteUInt16(file, neHeaderOffset + 0x28, residentNameOffset + 2); //module ref table (empty)
-            WriteUInt32(file, neHeaderOffset + 0x2C, (uint) file.Length);     //non-resident names (empty)
-            //LogicalSectorAlignmentShift (0x32), table lengths, and counts stay 0
-
-            //Segment table: one fixed code segment with relocation info present but empty
-            WriteUInt16(file, neHeaderOffset + segmentTableOffset, segmentDataOffset);
-            WriteUInt16(file, neHeaderOffset + segmentTableOffset + 2, (ushort) code.Length);
-            WriteUInt16(file, neHeaderOffset + segmentTableOffset + 4, 0x0100); //code + HasRelocationInfo
-            WriteUInt16(file, neHeaderOffset + segmentTableOffset + 6, (ushort) code.Length);
-
-            //Entry table (count byte 0) and resident name table (terminator) are already zeroed
-
-            //Segment data followed by a zero-entry relocation table
-            Array.Copy(code, 0, file, segmentDataOffset, code.Length);
-            WriteUInt16(file, segmentDataOffset + code.Length, 0);
-
-            return file;
-        }
-
-        private static void WriteUInt16(byte[] buffer, int offset, ushort value) =>
-            Array.Copy(BitConverter.GetBytes(value), 0, buffer, offset, 2);
-
-        private static void WriteUInt32(byte[] buffer, int offset, uint value) =>
-            Array.Copy(BitConverter.GetBytes(value), 0, buffer, offset, 4);
     }
 }

--- a/MBBSDASM.Tests/Dasm/RelativeOffsetTests.cs
+++ b/MBBSDASM.Tests/Dasm/RelativeOffsetTests.cs
@@ -1,0 +1,32 @@
+using MBBSDASM.Dasm;
+using Xunit;
+
+namespace MBBSDASM.Tests.Dasm
+{
+    public class RelativeOffsetTests
+    {
+        [Theory]
+        [InlineData(0x03, 1, 2, 6)]        //jmp short forward
+        [InlineData(0x7F, 0x100, 2, 0x181)] //maximum forward displacement
+        [InlineData(0xFE, 0x50, 2, 0x50)]  //-2: jump to own instruction
+        [InlineData(0x80, 0x100, 2, 0x82)] //maximum backward displacement (-128)
+        public void ToRelativeOffset8_ComputesTarget(byte operand, ulong currentOffset, int instructionLength,
+            ulong expected)
+        {
+            Assert.Equal(expected, Disassembler.ToRelativeOffset8(operand, currentOffset, instructionLength));
+        }
+
+        [Theory]
+        [InlineData(0x0081, 0x10, 3, 0x94)]    //jmp near forward
+        [InlineData(0x7FFF, 0x10, 3, 0x8012)]  //maximum forward displacement (boundary)
+        [InlineData(0xFF25, 0xE9, 3, 0x11)]    //-219: backward jmp near
+        [InlineData(0xFFFD, 0x100, 3, 0x100)]  //-3: jump to own instruction
+        [InlineData(0xFFF7, 6, 4, 1)]          //-9: backward 0F 8x conditional (4 byte instruction)
+        [InlineData(0x8000, 0x9000, 3, 0x1003)] //maximum backward displacement (-32768)
+        public void ToRelativeOffset16_ComputesTarget(ushort operand, ulong currentOffset, int instructionLength,
+            ulong expected)
+        {
+            Assert.Equal(expected, Disassembler.ToRelativeOffset16(operand, currentOffset, instructionLength));
+        }
+    }
+}

--- a/MBBSDASM.Tests/MBBSDASM.Tests.csproj
+++ b/MBBSDASM.Tests/MBBSDASM.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MBBSDASM\MBBSDASM.csproj" />
+  </ItemGroup>
+</Project>

--- a/MBBSDASM.Tests/MinimalNEFile.cs
+++ b/MBBSDASM.Tests/MinimalNEFile.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace MBBSDASM.Tests
+{
+    /// <summary>
+    ///     Builds the smallest NE file NEFile.Load will accept: MZ stub, NE header,
+    ///     one fixed code segment (with an empty relocation table), an optional entry
+    ///     table, and empty name tables
+    /// </summary>
+    internal static class MinimalNEFile
+    {
+        public static byte[] Build(byte[] code, byte[] entryTable = null)
+        {
+            const int neHeaderOffset = 0x80;
+            const int segmentTableOffset = 0x40;  //relative to NE header
+            const int entryTableOffset = 0x50;    //relative to NE header
+            const int segmentDataOffset = 0x100;
+
+            //An empty entry table is a single end-of-table bundle
+            entryTable = entryTable ?? new byte[] {0x00};
+
+            //Resident name table (a lone terminator byte) sits right after the entry table
+            var residentNameOffset = entryTableOffset + entryTable.Length;
+
+            var file = new byte[0x200];
+
+            //MZ stub
+            WriteUInt16(file, 0x00, 0x5A4D);            //'MZ'
+            file[0x18] = 0x40;                          //relocation table at 0x40 -> NE offset at 0x3C is valid
+            WriteUInt16(file, 0x3C, neHeaderOffset);
+
+            //NE header
+            file[neHeaderOffset] = (byte) 'N';
+            file[neHeaderOffset + 1] = (byte) 'E';
+            WriteUInt16(file, neHeaderOffset + 0x04, entryTableOffset);
+            WriteUInt16(file, neHeaderOffset + 0x1C, 1);                    //segment table entries
+            WriteUInt16(file, neHeaderOffset + 0x22, segmentTableOffset);
+            WriteUInt16(file, neHeaderOffset + 0x26, (ushort) residentNameOffset);
+            WriteUInt16(file, neHeaderOffset + 0x28, (ushort) (residentNameOffset + 2)); //module ref table (empty)
+            WriteUInt32(file, neHeaderOffset + 0x2C, (uint) file.Length);   //non-resident names (empty)
+            //LogicalSectorAlignmentShift (0x32), table lengths, and counts stay 0
+
+            //Segment table: one fixed code segment with relocation info present but empty
+            WriteUInt16(file, neHeaderOffset + segmentTableOffset, segmentDataOffset);
+            WriteUInt16(file, neHeaderOffset + segmentTableOffset + 2, (ushort) code.Length);
+            WriteUInt16(file, neHeaderOffset + segmentTableOffset + 4, 0x0100); //code + HasRelocationInfo
+            WriteUInt16(file, neHeaderOffset + segmentTableOffset + 6, (ushort) code.Length);
+
+            //Entry table; the resident name table terminator after it is already zeroed
+            Array.Copy(entryTable, 0, file, neHeaderOffset + entryTableOffset, entryTable.Length);
+
+            //Segment data followed by a zero-entry relocation table
+            Array.Copy(code, 0, file, segmentDataOffset, code.Length);
+            WriteUInt16(file, segmentDataOffset + code.Length, 0);
+
+            return file;
+        }
+
+        private static void WriteUInt16(byte[] buffer, int offset, ushort value) =>
+            Array.Copy(BitConverter.GetBytes(value), 0, buffer, offset, 2);
+
+        private static void WriteUInt32(byte[] buffer, int offset, uint value) =>
+            Array.Copy(BitConverter.GetBytes(value), 0, buffer, offset, 4);
+    }
+}

--- a/MBBSDASM.sln
+++ b/MBBSDASM.sln
@@ -2,15 +2,44 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MBBSDASM", "MBBSDASM\MBBSDASM.csproj", "{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MBBSDASM.Tests", "MBBSDASM.Tests\MBBSDASM.Tests.csproj", "{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Debug|x64.Build.0 = Debug|Any CPU
+		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Debug|x86.Build.0 = Debug|Any CPU
 		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Release|x64.Build.0 = Release|Any CPU
+		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA98FDB5-ACB6-4828-9A7F-C78318CD0E54}.Release|x86.Build.0 = Release|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Debug|x64.Build.0 = Debug|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Debug|x86.Build.0 = Debug|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Release|x64.ActiveCfg = Release|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Release|x64.Build.0 = Release|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Release|x86.ActiveCfg = Release|Any CPU
+		{DFFED4DD-D8AA-4378-8CD7-370FDE46BB07}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/MBBSDASM/Artifacts/NEFile.cs
+++ b/MBBSDASM/Artifacts/NEFile.cs
@@ -159,13 +159,18 @@ namespace MBBSDASM.Artifacts
                 while (WindowsHeader.EntryTableOffset + entryByteOffset  < WindowsHeader.NonResidentNameTableOffset)
                 {
                     //0xFF is moveable (6 bytes), anything else is fixed as it becomes the segment number
-                    var entryCount = data[WindowsHeader.EntryTableOffset + entryByteOffset]; 
+                    var entryCount = data[WindowsHeader.EntryTableOffset + entryByteOffset];
                     var entrySegment = data[WindowsHeader.EntryTableOffset + entryByteOffset + 1];
 
-                    if (entryCount == 1  && entrySegment == 0)
+                    //A bundle count of 0 marks the end of the Entry Table
+                    if (entryCount == 0)
+                        break;
+
+                    //Null bundles are 2 bytes and reserve entryCount unused ordinals
+                    if (entrySegment == 0)
                     {
                         entryByteOffset += 2;
-                        entryOrdinal += 1;
+                        entryOrdinal += entryCount;
                         continue;
                     }
 
@@ -189,6 +194,7 @@ namespace MBBSDASM.Artifacts
                             entry.Offset =
                                 BitConverter.ToUInt16(FileContent,
                                     WindowsHeader.EntryTableOffset + entryByteOffset + 6 + entrySize * i);
+                            entry.Ordinal = entryOrdinal;
                         }
                         entryOrdinal++;
                         EntryTable.Add(entry);

--- a/MBBSDASM/Dasm/Disassembler.cs
+++ b/MBBSDASM/Dasm/Disassembler.cs
@@ -338,36 +338,40 @@ namespace MBBSDASM.Dasm
                 0xEB, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x7E, 0x7F,
                 0xE3
             };
-            var jumpNearOps1stByte = new[] {0xE9, 0x0F};
             var jumpNearOps2ndByte = new[]
-                {0x80, 0x81, 0x82, 0x83, 0x84, 0x5, 0x86, 0x87, 0x88, 0x89, 0x8A, 0x8B, 0x8C, 0x8D, 0x8E, 0x8F};
+                {0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8A, 0x8B, 0x8C, 0x8D, 0x8E, 0x8F};
 
             foreach (var segment in file.SegmentTable.Where(x =>
                 x.Flags.Contains(EnumSegmentFlags.Code) && x.DisassemblyLines.Count > 0))
             {
-                //Only op+operand <= 3 bytes, skip jmp word ptr because we won't be able to label those
                 foreach (var disassemblyLine in segment.DisassemblyLines.Where(x =>
-                    MnemonicGroupings.JumpGroup.Contains(x.Disassembly.Mnemonic) && x.Disassembly.Bytes.Length <= 3))
+                    MnemonicGroupings.JumpGroup.Contains(x.Disassembly.Mnemonic)))
                 {
-                    ulong target = 0;
+                    var bytes = disassemblyLine.Disassembly.Bytes;
+                    ulong target;
 
                     //Jump Short, Relative to next Instruction (8 bit)
-                    if (jumpShortOps.Contains(disassemblyLine.Disassembly.Bytes[0]))
+                    if (bytes.Length == 2 && jumpShortOps.Contains(bytes[0]))
                     {
-                        target = ToRelativeOffset8(disassemblyLine.Disassembly.Bytes[1],
-                            disassemblyLine.Disassembly.Offset, disassemblyLine.Disassembly.Bytes.Length);
+                        target = ToRelativeOffset8(bytes[1],
+                            disassemblyLine.Disassembly.Offset, bytes.Length);
                     }
-
-                    //Jump Near, Relative to next Instruction (16 bit)
-                    //Check to see if it's a 1 byte unconditinoal or a 2 byte conditional
-                    if (jumpNearOps1stByte.Contains(disassemblyLine.Disassembly.Bytes[0]) &&
-                        (disassemblyLine.Disassembly.Bytes[0] == 0xE9 ||
-                         jumpNearOps2ndByte.Contains(disassemblyLine.Disassembly.Bytes[1])))
+                    //Jump Near Unconditional, Relative to next Instruction (16 bit)
+                    else if (bytes.Length == 3 && bytes[0] == 0xE9)
                     {
-                        target = ToRelativeOffset16(BitConverter.ToUInt16(disassemblyLine.Disassembly.Bytes,
-                                disassemblyLine.Disassembly.Bytes[0] == 0xE9 ? 1 : 2),
-                            disassemblyLine.Disassembly.Offset,
-                            disassemblyLine.Disassembly.Bytes.Length);
+                        target = ToRelativeOffset16(BitConverter.ToUInt16(bytes, 1),
+                            disassemblyLine.Disassembly.Offset, bytes.Length);
+                    }
+                    //Jump Near Conditional (2 byte opcode), Relative to next Instruction (16 bit)
+                    else if (bytes.Length == 4 && bytes[0] == 0x0F && jumpNearOps2ndByte.Contains(bytes[1]))
+                    {
+                        target = ToRelativeOffset16(BitConverter.ToUInt16(bytes, 2),
+                            disassemblyLine.Disassembly.Offset, bytes.Length);
+                    }
+                    else
+                    {
+                        //Register/memory-indirect jumps (jmp ax, jmp word ptr [..]) have no static target to label
+                        continue;
                     }
 
                     //Set Target
@@ -482,16 +486,16 @@ namespace MBBSDASM.Dasm
         /// <param name="instructionLength"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong ToRelativeOffset16(ushort operand, ulong currentOffset, int instructionLength)
+        internal static ulong ToRelativeOffset16(ushort operand, ulong currentOffset, int instructionLength)
         {
-            if (operand < 0x7FFF)
+            if (operand <= 0x7FFF)
             {
                 //Near Forward Jump
                 return operand + currentOffset + (ulong) instructionLength;
             }
 
             //Near Backwards Jump
-            return currentOffset - (ushort) ~operand + (ulong) instructionLength;
+            return (ulong) ((long) currentOffset + instructionLength - ((ushort) ~operand + 1));
         }
 
         /// <summary>
@@ -502,7 +506,7 @@ namespace MBBSDASM.Dasm
         /// <param name="instructionLength"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong ToRelativeOffset8(byte operand, ulong currentOffset, int instructionLength)
+        internal static ulong ToRelativeOffset8(byte operand, ulong currentOffset, int instructionLength)
         {
             if (operand <= 0x7F)
             {

--- a/MBBSDASM/MBBSDASM.csproj
+++ b/MBBSDASM/MBBSDASM.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="MBBSDASM.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.5.11" />
     <PackageReference Include="SharpDisasm" Version="1.1.11" />

--- a/MBBSDASM/MBBSDASM.csproj
+++ b/MBBSDASM/MBBSDASM.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <LangVersion>7.2</LangVersion>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
Part of #5 (item 3). Two bugs in `NEFile.Load`'s entry-table parsing:

- **Null bundles desynced the table.** A null bundle (`count, 0x00`) is 2 bytes and reserves `count` unused ordinals, but only the `count == 1` case was handled — larger null bundles fell into the fixed-bundle path, consuming `2 + 3*count` bytes and misparsing everything after them. A bundle count of 0 marks the end of the table; parsing now stops there instead of running on toward the non-resident name table.
- **Movable entries never got an ordinal.** Only the fixed-bundle branch assigned `entry.Ordinal`, so movable exports could not be matched by name in `IdentifyEntryPoints` or the entry-table listing.

Most MBBS modules use fixed segments and simple entry tables, which is why these stayed hidden.

Stacked on #6 (it needs that PR's test project); the change under review is the last two commits. Happy to rebase once #6 lands.

## Verification

- New tests cover null-bundle ordinal reservation, movable-entry parsing (ordinal, segment, offset), and the end-of-table terminator. All three fail against the previous parser.
- WCCMMUD.DLL (fixed bundles only) produces an identical entry-table listing before and after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
