### PR TITLE
Fix string-argument signature resolution and renderer side effects

### DIFF
--- a/MBBSDASM.Tests/Analysis/SignatureResolutionTests.cs
+++ b/MBBSDASM.Tests/Analysis/SignatureResolutionTests.cs
@@ -1,0 +1,87 @@
+using System.IO;
+using System.Linq;
+using MBBSDASM.Artifacts;
+using MBBSDASM.Dasm;
+using Xunit;
+
+namespace MBBSDASM.Tests.Analysis
+{
+    /// <summary>
+    ///     End-to-end tests for imported function identification: a code segment
+    ///     calling into MAJORBBS via an IMPORTORDINAL relocation, with argument
+    ///     values resolved from the preceding instructions
+    /// </summary>
+    public class SignatureResolutionTests
+    {
+        private const ushort HaskeyOrdinal = 334;
+        private const ushort MsgscanOrdinal = 421;
+
+        private static NEFile Analyze(byte[] code, byte[] relocations, byte[] dataSegment = null)
+        {
+            var inputFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(inputFile, MinimalNEFile.Build(code,
+                    dataSegment: dataSegment, relocationRecords: relocations,
+                    importedModule: "MAJORBBS"));
+                var file = new Disassembler(inputFile).Disassemble();
+                MBBSDASM.Analysis.MBBS.Analyze(file);
+                return file;
+            }
+            finally
+            {
+                File.Delete(inputFile);
+            }
+        }
+
+        [Fact]
+        public void IntArgument_ResolvesSignature()
+        {
+            /*
+            *   0000: 6A 05            push 0x5
+            *   0002: 9A 00 00 00 00   call far MAJORBBS.334 (haskey)
+            *   0007: C3               ret
+            */
+            var code = new byte[] {0x6A, 0x05, 0x9A, 0x00, 0x00, 0x00, 0x00, 0xC3};
+
+            var file = Analyze(code, MinimalNEFile.ImportOrdinalRelocation(0x0003, HaskeyOrdinal));
+
+            var callLine = file.SegmentTable[0].DisassemblyLines.First(x => x.Disassembly.Offset == 0x2);
+            Assert.Contains("int haskey(lock);", callLine.Comments);
+            Assert.Contains("Resolved Signature: int haskey(5);", callLine.Comments);
+        }
+
+        [Fact]
+        public void StringArguments_ResolveSignature()
+        {
+            /*
+            *   0000: 1E               push ds
+            *   0001: 68 06 00         push 0x6    -> "VBL" in the data segment
+            *   0004: 1E               push ds
+            *   0005: 68 01 00         push 0x1    -> "FILE" in the data segment
+            *   0008: 9A 00 00 00 00   call far MAJORBBS.421 (msgscan)
+            *   000D: C3               ret
+            */
+            var code = new byte[]
+            {
+                0x1E,
+                0x68, 0x06, 0x00,
+                0x1E,
+                0x68, 0x01, 0x00,
+                0x9A, 0x00, 0x00, 0x00, 0x00,
+                0xC3
+            };
+            var data = new byte[]
+            {
+                0x00,
+                (byte) 'F', (byte) 'I', (byte) 'L', (byte) 'E', 0x00, //offset 1
+                (byte) 'V', (byte) 'B', (byte) 'L', 0x00              //offset 6
+            };
+
+            var file = Analyze(code, MinimalNEFile.ImportOrdinalRelocation(0x0009, MsgscanOrdinal), data);
+
+            var callLine = file.SegmentTable[0].DisassemblyLines.First(x => x.Disassembly.Offset == 0x8);
+            Assert.Contains("Resolved Signature: char *msgscan(\"FILE\",\"VBL\");", callLine.Comments);
+        }
+    }
+}

--- a/MBBSDASM.Tests/MinimalNEFile.cs
+++ b/MBBSDASM.Tests/MinimalNEFile.cs
@@ -4,27 +4,36 @@ namespace MBBSDASM.Tests
 {
     /// <summary>
     ///     Builds the smallest NE file NEFile.Load will accept: MZ stub, NE header,
-    ///     one fixed code segment (with an empty relocation table), an optional entry
-    ///     table, and empty name tables
+    ///     a fixed code segment (with an empty relocation table), and optionally an
+    ///     entry table, a data segment, relocation records, and one imported module
     /// </summary>
     internal static class MinimalNEFile
     {
         public const ushort CodeWithRelocationInfo = 0x0100;
 
         public static byte[] Build(byte[] code, byte[] entryTable = null,
-            ushort segmentFlags = CodeWithRelocationInfo)
+            ushort segmentFlags = CodeWithRelocationInfo, byte[] dataSegment = null,
+            byte[] relocationRecords = null, string importedModule = null)
         {
             const int neHeaderOffset = 0x80;
             const int segmentTableOffset = 0x40;  //relative to NE header
             const int entryTableOffset = 0x50;    //relative to NE header
-            const int segmentDataOffset = 0x100;
+            const int codeDataOffset = 0x100;
+            const int dataDataOffset = 0x180;
 
             //An empty entry table is a single end-of-table bundle
             entryTable = entryTable ?? new byte[] {0x00};
 
-            //Resident name table (a lone terminator byte) sits right after the entry table
+            //Tables are packed after the entry table: resident name terminator,
+            //module reference table, imported names table
             var residentNameOffset = entryTableOffset + entryTable.Length;
+            var moduleRefOffset = residentNameOffset + 1;
+            var importedNamesOffset = moduleRefOffset + (importedModule != null ? 2 : 0);
 
+            if (importedNamesOffset + (importedModule?.Length + 2 ?? 0) > 0x80)
+                throw new InvalidOperationException("Tables overflow the space reserved before segment data");
+
+            var segmentCount = dataSegment != null ? 2 : 1;
             var file = new byte[0x200];
 
             //MZ stub
@@ -36,28 +45,68 @@ namespace MBBSDASM.Tests
             file[neHeaderOffset] = (byte) 'N';
             file[neHeaderOffset + 1] = (byte) 'E';
             WriteUInt16(file, neHeaderOffset + 0x04, entryTableOffset);
-            WriteUInt16(file, neHeaderOffset + 0x1C, 1);                    //segment table entries
+            WriteUInt16(file, neHeaderOffset + 0x1C, (ushort) segmentCount);
+            WriteUInt16(file, neHeaderOffset + 0x1E, (ushort) (importedModule != null ? 1 : 0));
             WriteUInt16(file, neHeaderOffset + 0x22, segmentTableOffset);
             WriteUInt16(file, neHeaderOffset + 0x26, (ushort) residentNameOffset);
-            WriteUInt16(file, neHeaderOffset + 0x28, (ushort) (residentNameOffset + 2)); //module ref table (empty)
+            WriteUInt16(file, neHeaderOffset + 0x28, (ushort) moduleRefOffset);
+            WriteUInt16(file, neHeaderOffset + 0x2A, (ushort) importedNamesOffset);
             WriteUInt32(file, neHeaderOffset + 0x2C, (uint) file.Length);   //non-resident names (empty)
             //LogicalSectorAlignmentShift (0x32), table lengths, and counts stay 0
 
-            //Segment table: one fixed segment
-            WriteUInt16(file, neHeaderOffset + segmentTableOffset, segmentDataOffset);
+            //Segment table: fixed code segment, then an optional data segment
+            WriteUInt16(file, neHeaderOffset + segmentTableOffset, codeDataOffset);
             WriteUInt16(file, neHeaderOffset + segmentTableOffset + 2, (ushort) code.Length);
             WriteUInt16(file, neHeaderOffset + segmentTableOffset + 4, segmentFlags);
             WriteUInt16(file, neHeaderOffset + segmentTableOffset + 6, (ushort) code.Length);
+            if (dataSegment != null)
+            {
+                WriteUInt16(file, neHeaderOffset + segmentTableOffset + 8, dataDataOffset);
+                WriteUInt16(file, neHeaderOffset + segmentTableOffset + 10, (ushort) dataSegment.Length);
+                WriteUInt16(file, neHeaderOffset + segmentTableOffset + 12, 0x0001); //data
+                WriteUInt16(file, neHeaderOffset + segmentTableOffset + 14, (ushort) dataSegment.Length);
+            }
 
             //Entry table; the resident name table terminator after it is already zeroed
             Array.Copy(entryTable, 0, file, neHeaderOffset + entryTableOffset, entryTable.Length);
 
-            //Segment data, followed by a zero-entry relocation table when the flag is set
-            Array.Copy(code, 0, file, segmentDataOffset, code.Length);
+            //Module reference and imported names tables (the first imported-names byte is unused)
+            if (importedModule != null)
+            {
+                WriteUInt16(file, neHeaderOffset + moduleRefOffset, 1); //name offset within imported names table
+                file[neHeaderOffset + importedNamesOffset + 1] = (byte) importedModule.Length;
+                for (var i = 0; i < importedModule.Length; i++)
+                    file[neHeaderOffset + importedNamesOffset + 2 + i] = (byte) importedModule[i];
+            }
+
+            //Code segment data, followed by its relocation table when the flag is set
+            Array.Copy(code, 0, file, codeDataOffset, code.Length);
             if ((segmentFlags & 0x0100) != 0)
-                WriteUInt16(file, segmentDataOffset + code.Length, 0);
+            {
+                relocationRecords = relocationRecords ?? new byte[0];
+                WriteUInt16(file, codeDataOffset + code.Length, (ushort) (relocationRecords.Length / 8));
+                Array.Copy(relocationRecords, 0, file, codeDataOffset + code.Length + 2,
+                    relocationRecords.Length);
+            }
+
+            if (dataSegment != null)
+                Array.Copy(dataSegment, 0, file, dataDataOffset, dataSegment.Length);
 
             return file;
+        }
+
+        /// <summary>
+        ///     A relocation record importing an ordinal from module 1 (8 bytes)
+        /// </summary>
+        public static byte[] ImportOrdinalRelocation(ushort operandOffset, ushort ordinal)
+        {
+            var record = new byte[8];
+            record[0] = 0x03; //source type: 16-bit segment:offset pointer
+            record[1] = 0x01; //IMPORTORDINAL
+            WriteUInt16(record, 2, operandOffset);
+            WriteUInt16(record, 4, 1); //module reference index
+            WriteUInt16(record, 6, ordinal);
+            return record;
         }
 
         private static void WriteUInt16(byte[] buffer, int offset, ushort value) =>

--- a/MBBSDASM.Tests/Renderer/StringRendererTests.cs
+++ b/MBBSDASM.Tests/Renderer/StringRendererTests.cs
@@ -28,5 +28,27 @@ namespace MBBSDASM.Tests.Renderer
                 File.Delete(inputFile);
             }
         }
+
+        [Fact]
+        public void RenderDisassembly_IsRepeatable()
+        {
+            //Rendering must not mutate the model: a second render produces identical output
+            var inputFile = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllBytes(inputFile, MinimalNEFile.Build(new byte[] {0xEB, 0xFE, 0xC3}));
+                var file = new Disassembler(inputFile).Disassemble();
+
+                var renderer = new StringRenderer(file);
+                var first = renderer.RenderDisassembly();
+                var second = renderer.RenderDisassembly();
+
+                Assert.Equal(first, second);
+            }
+            finally
+            {
+                File.Delete(inputFile);
+            }
+        }
     }
 }

--- a/MBBSDASM/Analysis/MBBS.cs
+++ b/MBBSDASM/Analysis/MBBS.cs
@@ -118,12 +118,9 @@ namespace MBBSDASM.Analysis
                                     values.Add(i.Disassembly.Operands[0].LvalSDWord);
                                     break;
                                 case "string":
-                                    if (i.Comments.Any(x => x.Contains("reference")))
-                                    {
-                                        var resolvedStringComment = i.Comments.First(x => x.Contains("reference"));
-                                        values.Add(resolvedStringComment.Substring(
-                                            resolvedStringComment.IndexOf('\"')));
-                                    }
+                                    //Only resolve when the string reference is unambiguous
+                                    if (i.StringReference != null && i.StringReference.Count == 1)
+                                        values.Add($"\"{i.StringReference[0].Value}\"");
                                     break;
                                 case "char":
                                     values.Add((char)i.Disassembly.Operands[0].LvalSDWord);

--- a/MBBSDASM/Artifacts/NEFile.cs
+++ b/MBBSDASM/Artifacts/NEFile.cs
@@ -33,7 +33,7 @@ namespace MBBSDASM.Artifacts
         {
             FileContent = File.ReadAllBytes(file);
             var f = new FileInfo(file);
-            Path = f.DirectoryName + "\\";
+            Path = f.DirectoryName + System.IO.Path.DirectorySeparatorChar;
             FileName = f.Name;
             Load();
         }

--- a/MBBSDASM/Dasm/Disassembler.cs
+++ b/MBBSDASM/Dasm/Disassembler.cs
@@ -223,13 +223,14 @@ namespace MBBSDASM.Dasm
         /// <param name="file"></param>
         private void ResolveStringReferences(NEFile file)
         {
-            var flagNext = false;
-            var dataSegmentToUse = 0;
             foreach (var segment in file.SegmentTable)
             {
                 if (!segment.Flags.Contains(EnumSegmentFlags.Code) || segment.DisassemblyLines == null ||
                     segment.DisassemblyLines.Count == 0)
                     continue;
+
+                var flagNext = false;
+                var dataSegmentToUse = 0;
 
                 foreach (var disassemblyLine in segment.DisassemblyLines)
                 {
@@ -242,9 +243,10 @@ namespace MBBSDASM.Dasm
                         !disassemblyLine.Disassembly.ToString().Contains(":"))
                     {
                         //MOV ax, SEG ADDR sets the current Data Segment to use
-                        if (disassemblyLine.BranchToRecords.Any(x =>
-                            x.IsRelocation && x.BranchType == EnumBranchType.SegAddr))
-                            dataSegmentToUse = disassemblyLine.BranchToRecords.First().Segment;
+                        var segAddrRecord = disassemblyLine.BranchToRecords.FirstOrDefault(x =>
+                            x.IsRelocation && x.BranchType == EnumBranchType.SegAddr);
+                        if (segAddrRecord != null)
+                            dataSegmentToUse = segAddrRecord.Segment;
 
 
                         if (dataSegmentToUse > 0)

--- a/MBBSDASM/Renderer/impl/StringRenderer.cs
+++ b/MBBSDASM/Renderer/impl/StringRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using MBBSDASM.Artifacts;
@@ -106,10 +107,13 @@ namespace MBBSDASM.Renderer.impl
                 //Write each line of the disassembly to the output stream
                 foreach (var d in s.DisassemblyLines)
                 {
+                    //Rendering labels are built locally so rendering doesn't mutate the model
+                    var comments = new List<string>(d.Comments ?? Enumerable.Empty<string>());
+
                     //Label Entrypoints/Exported Functions
                     if (d.ExportedFunction != null)
                     {
-                        d.Comments.Add($"Exported Function: {d.ExportedFunction.Name}");
+                        comments.Add($"Exported Function: {d.ExportedFunction.Name}");
                     }
 
                     //Label Branch Targets
@@ -118,12 +122,12 @@ namespace MBBSDASM.Renderer.impl
                         switch (b.BranchType)
                         {
                             case EnumBranchType.Call:
-                                d.Comments.Add(
+                                comments.Add(
                                     $"Referenced by CALL at address: {b.Segment:0000}.{b.Offset:X4}h {(b.IsRelocation ? "(Relocation)" : string.Empty)}");
                                 break;
                             case EnumBranchType.Conditional:
                             case EnumBranchType.Unconditional:
-                                d.Comments.Add(
+                                comments.Add(
                                     $"{(b.BranchType == EnumBranchType.Conditional ? "Conditional" : "Unconditional")} jump from {b.Segment:0000}:{b.Offset:X4}h");
                                 break;
                         }
@@ -132,17 +136,17 @@ namespace MBBSDASM.Renderer.impl
                     //Label Branch Origins (Relocation)
                     foreach (var b in d.BranchToRecords.Where(x =>
                         x.IsRelocation && x.BranchType == EnumBranchType.Call))
-                        d.Comments.Add($"CALL {b.Segment:0000}.{b.Offset:X4}h (Relocation)");
+                        comments.Add($"CALL {b.Segment:0000}.{b.Offset:X4}h (Relocation)");
 
                     //Label Refereces by SEG ADDR (Internal)
                     foreach (var b in d.BranchToRecords.Where(x =>
                         x.IsRelocation && x.BranchType == EnumBranchType.SegAddr))
-                        d.Comments.Add($"SEG ADDR of Segment {b.Segment}");
+                        comments.Add($"SEG ADDR of Segment {b.Segment}");
 
                     //Label String References
                     if (d.StringReference != null)
                         foreach (var sr in d.StringReference)
-                            d.Comments.Add($"Possible String reference from SEG {sr.Segment} -> \"{sr.Value}\"");
+                            comments.Add($"Possible String reference from SEG {sr.Segment} -> \"{sr.Value}\"");
 
                     //Only label Imports if Analysis is off, because Analysis does much more in-depth labeling
                     if (!analysis)
@@ -150,17 +154,17 @@ namespace MBBSDASM.Renderer.impl
                         foreach (var b in d.BranchToRecords?.Where(x =>
                             x.IsRelocation && (x.BranchType == EnumBranchType.CallImport ||
                                                x.BranchType == EnumBranchType.SegAddrImport)))
-                            d.Comments.Add(
+                            comments.Add(
                                 $"{(b.BranchType == EnumBranchType.CallImport ? "call" : "SEG ADDR of")} {_inputFile.ImportedNameTable.FirstOrDefault(x => x.Ordinal == b.Segment)?.Name}.Ord({b.Offset:X4}h)");
                     }
 
                     var sOutputLine =
                         $"{d.Disassembly.Offset + s.Offset:X8}h:{s.Ordinal:0000}.{d.Disassembly.Offset:X4}h {BitConverter.ToString(d.Disassembly.Bytes).Replace("-", string.Empty).PadRight(Constants.MAX_INSTRUCTION_LENGTH, ' ')} {d.Disassembly}";
-                    if (d.Comments != null && d.Comments.Count > 0)
+                    if (comments.Count > 0)
                     {
                         var newLine = false;
                         var firstCommentIndex = 0;
-                        foreach (var c in d.Comments)
+                        foreach (var c in comments)
                         {
                             if (!newLine)
                             {

--- a/MBBSDASM/UI/impl/ConsoleUI.cs
+++ b/MBBSDASM/UI/impl/ConsoleUI.cs
@@ -127,8 +127,8 @@ namespace MBBSDASM.UI.impl
                 var dasm = new Disassembler(_sInputFile);
                 var inputFile = dasm.Disassemble(_bMinimal);
 
-                //Apply Selected Analysis
-                if (_bAnalysis)
+                //Apply Selected Analysis (unavailable with minimal output, as warned above)
+                if (_bAnalysis && !_bMinimal)
                 {
                     _logger.Info($"Performing Additional Analysis");
                     Analysis.MBBS.Analyze(inputFile);


### PR DESCRIPTION
Part of #5 (items 5 and 6 — the last two). Based on current master, no stacking this time.

**String-argument signature resolution was dead code.** `ImportedFunctionIdentification` resolved string arguments by scraping comments containing `"reference"`, but those comments are only added later, by `StringRenderer.RenderDisassembly` — at analysis time they don't exist, so string-typed arguments never resolved. The data was already on the line in `StringReference`; analysis now reads it directly, and emits the value only when the candidate is unambiguous (exactly one matching string). Two smaller fixes in `ResolveStringReferences`: the data-segment lookup checked `Any(x => x.IsRelocation && SegAddr)` but then read `First()` unfiltered, and `flagNext`/`dataSegmentToUse` leaked across segments.

**Item 6 leftovers ride along:**
- `RenderDisassembly` appended its labels into the shared `DisassemblyLine` model, so rendering twice duplicated every comment. Labels are now built into a local list per line.
- `NEFile.Path` used a hardcoded `"\\"`; now `Path.DirectorySeparatorChar`.
- `ConsoleUI` warned that `-ANALYSIS` is unavailable with `-MINIMAL` but ran the analysis anyway; it now skips it as the warning says.

## Verification

- The test builder now supports a data segment, relocation records, and an imported module, enabling end-to-end signature tests: `push 0x5; call far MAJORBBS.334` resolves `int haskey(5);`, and a two-string `msgscan` call site resolves `char *msgscan("FILE","VBL");`. A render-twice repeatability test covers the renderer fix. The string and repeatability tests fail against the previous code; the int-argument test passes on both (that path already worked, kept as a control).
- Against WCCMMUD.DLL with `-ANALYSIS`: exactly one new resolved signature appears — `char *msgscan("tcplibm.msg","SUBBBS");` — and all previously resolved signatures and string-reference labels are unchanged (FW_FTRIV.DLL likewise unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
